### PR TITLE
feat: allow day navigation in daily stats

### DIFF
--- a/src/routes/expenses/expenses.route.ts
+++ b/src/routes/expenses/expenses.route.ts
@@ -17,6 +17,7 @@ import {
   getDailyStatsByTripIdAction,
   getSummaryStatsByTripIdAction,
 } from "./stats/stats.action";
+import { dailyStatsQuery } from "./stats/stats.validator";
 
 const router = express.Router();
 
@@ -50,7 +51,7 @@ router
   .route("/expenses/trip/:tripId/stats/daily")
   .get(
     requireAuth,
-    validateData({ params: tripIdParams }),
+    validateData({ params: tripIdParams, query: dailyStatsQuery }),
     getDailyStatsByTripIdAction
   );
 

--- a/src/routes/expenses/stats/repositories/getDailyStatsByTripId.sql
+++ b/src/routes/expenses/stats/repositories/getDailyStatsByTripId.sql
@@ -10,4 +10,5 @@ SELECT
   max_spent_converted,
   top_category
 FROM daily_expense_stats
-WHERE trip_id = $1::uuid AND day = CURRENT_DATE;
+WHERE trip_id = $1::uuid
+  AND day = COALESCE($2::date, CURRENT_DATE);

--- a/src/routes/expenses/stats/stats.action.ts
+++ b/src/routes/expenses/stats/stats.action.ts
@@ -18,12 +18,14 @@ export const getDailyStatsByTripIdAction = async (
   logger.info("🔍 Retrieving daily stats for tripId and userId", {
     tripId: req.params.tripId,
     userId: req.userId,
+    day: req.query.day,
   });
 
   try {
     const dailyStats = await getDailyStatsByTripIdService(
       req.userId!,
-      req.params.tripId
+      req.params.tripId,
+      req.query.day ? new Date(req.query.day as string) : undefined
     );
     logger.info("✅ Trip daily stats retrieved successfully:", {
       length: dailyStats,

--- a/src/routes/expenses/stats/stats.service.ts
+++ b/src/routes/expenses/stats/stats.service.ts
@@ -14,9 +14,10 @@ import { STATS_DAL, STATS_ERRORS } from "./stats.constant";
 
 export const getDailyStatsByTripIdService = async (
   userId: string,
-  tripId: string
+  tripId: string,
+  day?: Date
 ): Promise<DAILY_STATS_CAMEL_DTO> => {
-  logger.info("🔍 Fetching daily stats for tripId:", { tripId, userId });
+  logger.info("🔍 Fetching daily stats for tripId:", { tripId, userId, day });
 
   const trip = await safeQueryOne<TRIPS_DTO>(dal[TRIPS_DAL.getTripById], [
     tripId,
@@ -31,7 +32,7 @@ export const getDailyStatsByTripIdService = async (
 
   const dailyStats = await safeQueryOne<DAILY_STATS_DTO>(
     dal[STATS_DAL.getDailyStatsByTripId],
-    [tripId]
+    [tripId, day]
   );
 
   if (!dailyStats) {

--- a/src/routes/expenses/stats/stats.validator.ts
+++ b/src/routes/expenses/stats/stats.validator.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+const dailyStatsQuery = z.object({
+  day: z.string().optional(),
+});
+
+export { dailyStatsQuery };


### PR DESCRIPTION
## Summary
- add optional `day` parameter to daily stats endpoint for day-to-day navigation
- default daily stats queries to current date when no day is provided

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a883cadb1c832e88b4963aa869ebc4